### PR TITLE
chore: align prompt_guard.engine.__version__ with package version

### DIFF
--- a/prompt_guard/engine.py
+++ b/prompt_guard/engine.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict, List, Any
 from prompt_guard.models import Severity, Action, DetectionResult, SanitizeResult
 from prompt_guard.cache import get_cache, MessageCache
 
-__version__ = "3.6.0"
+__version__ = "3.7.1"
 from prompt_guard.pattern_loader import TieredPatternLoader, LoadTier, get_loader
 from prompt_guard.patterns import (
     CRITICAL_PATTERNS,


### PR DESCRIPTION
## Summary

One-line fix. Bumps `prompt_guard/engine.py`'s `__version__` from `"3.6.0"` to `"3.7.1"` so it matches `prompt_guard.__version__` and `pyproject.toml`.

Pre-v3.7.1 the repo had three internal version strings drifting independently. PR #20 realigned `__init__.py` and `pyproject.toml`, but left `engine.py` alone by design (plan §2) to keep that PR focused. This closes the remaining drift.

## Verification

```
before: prompt_guard.__version__        == "3.7.1"
        prompt_guard.engine.__version__ == "3.6.0"   # stale

after:  prompt_guard.__version__        == "3.7.1"
        prompt_guard.engine.__version__ == "3.7.1"   # aligned
```

No behavioral change. `engine.__version__` is consumed in exactly one place — the API client's `client_version` telemetry field at `engine.py:153` — so aligning it also corrects version reporting from that surface.

## Test plan

- [x] Module import check: both values match at 3.7.1
- [x] Targeted regression: `tests/test_external_content.py` + `tests/test_detect_cli.py` — 29/29 pass

Recommended to merge before tagging `v3.7.1` so the tag points to a fully version-consistent tree.